### PR TITLE
Refac2gradle8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,11 @@ repositories {
 }
 
 dependencies {
-    compile 'net.sourceforge.plantuml:plantuml:1.2019.7'
+    implementation 'net.sourceforge.plantuml:plantuml:1.2019.7'
 
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.4.2'
-    testCompile 'org.junit-pioneer:junit-pioneer:0.3.0'
-    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
+    testImplementation 'org.junit-pioneer:junit-pioneer:0.3.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
 }
 
 gradlePlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-gradle-plugin'
-    id 'com.gradle.plugin-publish' version '0.10.1'
+    id 'com.gradle.plugin-publish' version '1.2.1'
     id 'groovy'
     id 'maven-publish'
 }
@@ -23,22 +23,19 @@ dependencies {
 }
 
 gradlePlugin {
+    website = 'https://github.com/cosminpolifronie/gradle-plantuml-plugin'
+    vcsUrl = 'https://github.com/cosminpolifronie/gradle-plantuml-plugin'
     plugins {
-        plantUmlPlugin {
+        create("plantUmlPlugin") {
             id = 'com.cosminpolifronie.gradle.plantuml'
             displayName = 'Gradle PlantUML Plugin'
             description = 'A simple plugin to render PlantUML files. ' +
                     'Takes a set of diagram files together with desired output files / formats ' +
                     'and renders them with PlantUML (http://plantuml.com/).'
             implementationClass = 'com.cosminpolifronie.gradle.plantuml.PlantUmlPlugin'
+            tags.set(["plantuml"])
         }
     }
-}
-
-pluginBundle {
-    website = 'https://github.com/cosminpolifronie/gradle-plantuml-plugin'
-    vcsUrl = 'https://github.com/cosminpolifronie/gradle-plantuml-plugin'
-    tags = ['plantuml']
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Jul 01 20:53:10 EEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip

--- a/src/main/groovy/com/cosminpolifronie/gradle/plantuml/PlantUmlRenderer.groovy
+++ b/src/main/groovy/com/cosminpolifronie/gradle/plantuml/PlantUmlRenderer.groovy
@@ -2,19 +2,14 @@ package com.cosminpolifronie.gradle.plantuml
 
 import net.sourceforge.plantuml.FileFormatOption
 import net.sourceforge.plantuml.SourceStringReader
+import org.gradle.workers.WorkAction
 
-import javax.inject.Inject
-
-class PlantUmlRenderer implements Runnable {
-    private final PlantUmlPreparedRender preparedRender
-
-    @Inject
-    PlantUmlRenderer(PlantUmlPreparedRender preparedRender) {
-        this.preparedRender = preparedRender
-    }
+abstract class PlantUmlRenderer implements WorkAction<PlantUmlRendererParameters> {
 
     @Override
-    void run() {
+    void execute() {
+        def preparedRender = getParameters().getPlantUmlPreparedRender()
+
         // TODO: the following can be simplified when/if the following pull request gets accepted
         // https://github.com/plantuml/plantuml/pull/220
         // all below becomes
@@ -31,7 +26,7 @@ class PlantUmlRenderer implements Runnable {
         }
 
         preparedRender.output.withOutputStream { out ->
-            new SourceStringReader(preparedRender.input.text).outputImage(out, fileFormatOption)
+            new SourceStringReader(getParameters().getPlantUmlPreparedRender().input.text).outputImage(out, fileFormatOption)
         }
     }
 }

--- a/src/main/groovy/com/cosminpolifronie/gradle/plantuml/PlantUmlRendererParameters.groovy
+++ b/src/main/groovy/com/cosminpolifronie/gradle/plantuml/PlantUmlRendererParameters.groovy
@@ -1,0 +1,7 @@
+package com.cosminpolifronie.gradle.plantuml
+
+import org.gradle.workers.WorkParameters
+
+class PlantUmlRendererParameters implements WorkParameters, Serializable {
+    PlantUmlPreparedRender plantUmlPreparedRender
+}

--- a/src/main/groovy/com/cosminpolifronie/gradle/plantuml/tasks/PlantUmlTask.groovy
+++ b/src/main/groovy/com/cosminpolifronie/gradle/plantuml/tasks/PlantUmlTask.groovy
@@ -1,6 +1,11 @@
 package com.cosminpolifronie.gradle.plantuml.tasks
 
-import com.cosminpolifronie.gradle.plantuml.*
+import com.cosminpolifronie.gradle.plantuml.PlantUmlException
+import com.cosminpolifronie.gradle.plantuml.PlantUmlPreparedRender
+import com.cosminpolifronie.gradle.plantuml.PlantUmlReceivedRender
+import com.cosminpolifronie.gradle.plantuml.PlantUmlRenderer
+import com.cosminpolifronie.gradle.plantuml.PlantUmlRendererParameters
+import com.cosminpolifronie.gradle.plantuml.PlantUmlUtils
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
@@ -12,8 +17,6 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.work.ChangeType
 import org.gradle.work.Incremental
 import org.gradle.work.InputChanges
-import org.gradle.workers.IsolationMode
-import org.gradle.workers.WorkerConfiguration
 import org.gradle.workers.WorkerExecutor
 
 import javax.inject.Inject
@@ -73,11 +76,10 @@ abstract class PlantUmlTask extends DefaultTask {
                 if (localInputPreparedRenderMap.containsKey(change.file)) {
                     def preparedRender = localInputPreparedRenderMap[change.file]
                     logger.lifecycle("[PlantUml] Rendering file ${preparedRender.input.toString()} to ${preparedRender.output.toString()}")
-                    localWorkerExecutor.submit(PlantUmlRenderer.class, new Action<WorkerConfiguration>() {
+                    localWorkerExecutor.noIsolation().submit(PlantUmlRenderer.class, new Action<PlantUmlRendererParameters>() {
                         @Override
-                        void execute(WorkerConfiguration workerConfiguration) {
-                            workerConfiguration.setIsolationMode(IsolationMode.NONE)
-                            workerConfiguration.params(preparedRender)
+                        void execute(PlantUmlRendererParameters workerConfiguration) {
+                            workerConfiguration.plantUmlPreparedRender = preparedRender
                         }
                     })
                 } else {

--- a/src/main/resources/META-INF/gradle-plugins/com.cosminpolifronie.gradle.plantuml.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.cosminpolifronie.gradle.plantuml.properties
@@ -1,1 +1,0 @@
-implementation-class=com.cosminpolifronie.gradle.plantuml.PlantUmlPlugin

--- a/src/test/groovy/com/cosminpolifronie/gradle/plantuml/PlantUmlPluginTest.groovy
+++ b/src/test/groovy/com/cosminpolifronie/gradle/plantuml/PlantUmlPluginTest.groovy
@@ -317,7 +317,10 @@ class PlantUmlPluginTest {
 
         def result = plantUmlIOTaskExecution().build()
         assert result.task(':plantUmlIO').outcome == SUCCESS
-        assert result.output.contentEquals('diagrams/first.puml,output/sub/first.png\r\ndiagrams/second.puml,output/sub/second.png\r\n')
+        def outputList = result.output.split('\n')
+        assert outputList.size() == 2
+        assert trimNewLine(outputList.getAt(0)).contentEquals('diagrams/first.puml,output/sub/first.png')
+        assert trimNewLine(outputList.getAt(1)).contentEquals('diagrams/second.puml,output/sub/second.png')
     }
 
     @Test
@@ -342,7 +345,7 @@ class PlantUmlPluginTest {
 
         def result = plantUmlOutputForInputTaskExecution("${diagramDir.name}/abc.puml").build()
         assert result.task(':plantUmlOutputForInput').outcome == SUCCESS
-        assert result.output.contentEquals('output/sub/abc.png\r\n')
+        assert trimNewLine(result.output).contentEquals('output/sub/abc.png')
     }
 
     @Test
@@ -367,7 +370,7 @@ class PlantUmlPluginTest {
 
         def result = plantUmlOutputForInputTaskExecution("${diagramDir.name}/first.puml").build()
         assert result.task(':plantUmlOutputForInput').outcome == SUCCESS
-        assert result.output.contentEquals('output/sub/first.png\r\n')
+        assert trimNewLine(result.output).contentEquals('output/sub/first.png')
     }
 
     @Test
@@ -424,5 +427,14 @@ class PlantUmlPluginTest {
         def expectedOutputName = diagramFile.name.replaceAll(/\.[^.]*/, format.fileSuffix)
         def expectedOutput = new File(rootDir, "output/sub/${expectedOutputName}")
         assert expectedOutput.exists(): 'Rendered diagram exists'
+    }
+
+    /**
+     * New line may be '\n' or '\r\n' depending on the OS.
+     * We strip it to get consistent test results
+     * @param text
+     */
+    private String trimNewLine(String text) {
+        return text.replaceAll("[\\n\\r]", "")
     }
 }


### PR DESCRIPTION
**Problem**
Previous implementation didn't run using gradle 8 because of some api changes in gradle.

Beause of this running the plantUml plugin failed

> Task :plantUml FAILED
[PlantUml] Gradle cannot use an incremental build - rendering everything
...
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':plantUml'.
> Could not find method submit() for arguments [class com.cosminpolifronie.gradle.plantuml.PlantUmlRenderer, com.cosminpolifronie.gradle.plantuml.tasks.PlantUmlTask$1@17fdfbab] on object of type org.gradle.workers.internal.DefaultWorkerExecutor.

**Solution**
I refactored implementation using the new gradle 8 api's and all seems to work again.

**TODO**
The test passes, but I haven't tested the plugin from cli.